### PR TITLE
Extended settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 				"ts-loader": "^9.4.1",
 				"typescript": "^4.9.3",
 				"webpack": "^5.75.0",
-				"webpack-cli": "^5.0.0"
+				"webpack-cli": "^5.1.4"
 			},
 			"engines": {
 				"vscode": "^1.73.0"

--- a/package.json
+++ b/package.json
@@ -120,6 +120,30 @@
 					"type": "boolean",
 					"default": false,
 					"markdownDescription": "If you have the 'Base Workspace' integration object merged into your Siebel MAIN workspace, by checking this setting you can get the workspaces from the Siebel REST API, no need to fill them manually under the Workspaces setting. The integration object to import can be found in the repository of the extension, under the name `BaseWorkspaceIOB.sif`. See the [documentation](https://github.com/endoit/siebelScriptsEditor/blob/main/documentation.md#213-getting-workspace-data-from-rest) for more information.  \nPress the Reload button on the extension after editing this setting!"
+				},
+				"siebelScriptAndWebTempEditor.defaultScriptFetching": {
+					"type": "string",
+					"enum": [
+						"None - always ask",
+						"Only method names",
+						"Full scripts"
+					],
+					"default": "Only method names",
+					"markdownDescription": " Default method for fetching sections in the tree-view:\nNone: always asks how to fetch.\nOnly method names: fetches only the method names of the section.\nFull scripts: always fetches all scripts of the section."
+				},
+				"siebelScriptAndWebTempEditor.singleFileAutoDownload": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "If you set this to true, scripts will always download, without asking for permission.\nWARNING: this overwrites files witch are already opened!"
+				},
+				"siebelScriptAndWebTempEditor.localFileExtension": {
+					"type": "string",
+					"enum": [
+						".js",
+						".ts"
+					],
+					"default": ".js",
+					"markdownDescription": "The default file extension for downoaded scripts."
 				}
 			}
 		},
@@ -161,6 +185,6 @@
 		"ts-loader": "^9.4.1",
 		"typescript": "^4.9.3",
 		"webpack": "^5.75.0",
-		"webpack-cli": "^5.0.0"
+		"webpack-cli": "^5.1.4"
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,6 +73,18 @@ export async function activate(context: vscode.ExtensionContext) {
     "siebelScriptAndWebTempEditor"
   )["getWorkspacesFromREST"];
 
+  const dfltScriptFetching: "Yes" | "No" | "Only method names" | "Full scripts" | "None - always ask" | undefined = vscode.workspace.getConfiguration(
+    "siebelScriptAndWebTempEditor"
+  )["defaultScriptFetching"];
+
+  const sglFileAutoDwnld: boolean = vscode.workspace.getConfiguration(
+    "siebelScriptAndWebTempEditor"
+  )["singleFileAutoDownload"];
+
+  const localFileExtension: string = vscode.workspace.getConfiguration(
+    "siebelScriptAndWebTempEditor"
+  )["localFileExtension"];
+
   const workspaces: string[] = vscode.workspace.getConfiguration(
     "siebelScriptAndWebTempEditor"
   )["workspaces"];
@@ -450,7 +462,10 @@ export async function activate(context: vscode.ExtensionContext) {
                         SERVICE,
                         selected,
                         busServObj,
-                        treeDataBS
+                        treeDataBS,
+                        sglFileAutoDwnld,
+                        localFileExtension,
+                        dfltScriptFetching
                       )
                     );
                     break;
@@ -472,7 +487,10 @@ export async function activate(context: vscode.ExtensionContext) {
                         BUSCOMP,
                         selected,
                         busCompObj,
-                        treeDataBC
+                        treeDataBC,
+                        sglFileAutoDwnld,
+                        localFileExtension,
+                        dfltScriptFetching
                       )
                     );
                     break;
@@ -494,7 +512,10 @@ export async function activate(context: vscode.ExtensionContext) {
                         APPLET,
                         selected,
                         appletObj,
-                        treeDataApplet
+                        treeDataApplet,
+                        sglFileAutoDwnld,
+                        localFileExtension,
+                        dfltScriptFetching
                       )
                     );
                     break;
@@ -516,7 +537,10 @@ export async function activate(context: vscode.ExtensionContext) {
                         APPLICATION,
                         selected,
                         applicationObj,
-                        treeDataApplication
+                        treeDataApplication,
+                        sglFileAutoDwnld,
+                        localFileExtension,
+                        dfltScriptFetching
                       )
                     );
                     break;
@@ -542,7 +566,10 @@ export async function activate(context: vscode.ExtensionContext) {
                         WEBTEMP,
                         selected,
                         webTempObj,
-                        treeDataWebTemp
+                        treeDataWebTemp,
+                        sglFileAutoDwnld,
+                        localFileExtension,
+                        dfltScriptFetching
                       )
                     );
                     break;

--- a/src/fileRW.ts
+++ b/src/fileRW.ts
@@ -7,6 +7,7 @@ export const writeFile = async (
   fileContent: string,
   folderPath: string,
   objectName: string,
+  localFileExtension: string,
   fileName?: string
 ): Promise<void> => {
   try {
@@ -14,7 +15,7 @@ export const writeFile = async (
     const wsPath = vscode.workspace.workspaceFolders?.[0]?.uri?.fsPath!;
     const filePath = vscode.Uri.file(
       `${wsPath}/${folderPath}/${objectName}${
-        fileName !== undefined ? `/${fileName}.js` : ".html"
+        fileName !== undefined ? `/${fileName}.${localFileExtension}` : ".html"
       }`
     );
     const wsEdit = new vscode.WorkspaceEdit();


### PR DESCRIPTION
Implemented 3 more settings for the extension:

**1. local file extension:**
specifies the file extension for downloaded scripts. Because in escript you can define types, it is more like typescript then like js. So this gives the possibillity to save scripts as .ts files.

**2. default fetch-type for method scripts in tree-view**
this defines the default fetch type for the methods of an entity. It can be:
None - always ask    (as it is in default - vscode always asks)
Only method names    (fetch method names without asking)
Full scripts    (fetch full scripts without asking)

**3. auto fetch single files** 
if true, always downloads script without asking for (see warning in settings)